### PR TITLE
Password validator added in user schema and test cases

### DIFF
--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -39,6 +39,20 @@ class UserBase(BaseModel):
 class UserCreate(UserBase):
     password: str = Field(..., example="Secure*1234")
 
+    @validator('password')
+    def validate_password_strength(cls, password: str) -> str:
+        if len(password) < 8:
+            raise ValueError("Password must be at least 8 characters long.")
+        if not re.search(r'[A-Z]', password):
+            raise ValueError("Password must include at least one uppercase letter.")
+        if not re.search(r'[a-z]', password):
+            raise ValueError("Password must include at least one lowercase letter.")
+        if not re.search(r'\d', password):
+            raise ValueError("Password must include at least one number.")
+        if not re.search(r'[!@#$%^&*(),.?":{}|<>]', password):
+            raise ValueError("Password must include at least one special character.")
+        return password
+
 class UserUpdate(UserBase):
     email: Optional[EmailStr] = Field(default=None, example="john.doe@example.com")
 

--- a/tests/test_schemas/test_user_schemas.py
+++ b/tests/test_schemas/test_user_schemas.py
@@ -67,3 +67,24 @@ def test_user_base_invalid_email(user_base_data_invalid):
     
     assert "value is not a valid email address" in str(exc_info.value)
     assert "john.doe.example.com" in str(exc_info.value)
+
+@pytest.mark.parametrize("password", [
+    "Password123!",    # valid
+    "GoodPass@2024",   # valid
+])
+def test_user_create_valid_password(password, user_create_data):
+    user_create_data["password"] = password
+    user = UserCreate(**user_create_data)
+    assert user.password == password
+
+@pytest.mark.parametrize("password", [
+    "short",                    # too short
+    "alllowercase123!",         # no uppercase
+    "ALLUPPERCASE123!",         # no lowercase
+    "NoDigitsHere!",            # no digits
+    "NoSpecialChar123",         # no special chars
+])
+def test_user_create_invalid_password(password, user_create_data):
+    user_create_data["password"] = password
+    with pytest.raises(ValidationError):
+        UserCreate(**user_create_data)


### PR DESCRIPTION
Fixes #5 
Added a Pydantic validator to the UserCreate schema.

Enforced the following rules:

At least 8 characters

One uppercase letter

One lowercase letter

One digit

One special character

Added test cases for both valid and invalid password